### PR TITLE
Search mods for any version

### DIFF
--- a/cogs/factorio.py
+++ b/cogs/factorio.py
@@ -331,7 +331,7 @@ class FactorioCog(commands.Cog):
                                colour=discord.Colour.gold())
             bufferMsg = await ctx.send(embed=em)
             async with ctx.channel.typing():
-                response = await get_soup(f"https://mods.factorio.com/query/{modname.title()}")
+                response = await get_soup(f"https://mods.factorio.com/query/{modname.title()}?version=any")
                 if response[0] == 200:
                     soup = response[1]
                     if " 0 " in soup.find("span", class_="active-filters-bar-total-mods").string:


### PR DESCRIPTION
Some people complained that the mod is not always finding mods for every version of the game.
Today I found by accident the query string ``?version=any`` for the search which fixes this problem.

![](https://cdn.discordapp.com/attachments/306402592265732098/708345792921862194/unknown.png)