### PR TITLE
Search in most downloaded instead of recently updated

### DIFF
--- a/cogs/factorio.py
+++ b/cogs/factorio.py
@@ -334,7 +334,7 @@ class FactorioCog(commands.Cog):
                                colour=discord.Colour.gold())
             bufferMsg = await ctx.send(embed=em)
             async with ctx.channel.typing():
-                response = await get_soup(f"https://mods.factorio.com/query/{modname.title()}?version=any")
+                response = await get_soup(f"https://mods.factorio.com/query/{modname.title()}/downloaded/1?version=any")
                 if response[0] == 200:
                     soup = response[1]
                     if " 0 " in soup.find("div", class_="grey").string:


### PR DESCRIPTION
Changed the search URL to search in most downloaded mods instead of recently updated, as the bot currently often fails to find large overhaul mods, even when given an exact name.
For example Krastorio 2, which currently doesn't even show up on the first page when searching in recently updated: https://mods.factorio.com/query/Krastorio%202?version=1.1